### PR TITLE
Add JSON.parse when calling onMount

### DIFF
--- a/src/react-persist.tsx
+++ b/src/react-persist.tsx
@@ -27,7 +27,7 @@ export class Persist extends React.Component<PersistProps, {}> {
   componentDidMount() {
     const data = window.localStorage.getItem(this.props.name);
     if (data && data !== null) {
-      this.props.onMount(data);
+      this.props.onMount(JSON.parse(data));
     }
   }
 


### PR DESCRIPTION
Previously, onMount just passed the data without parsing the JSON. 
```ts
componentDidMount() {
    const data = window.localStorage.getItem(this.props.name);
    if (data && data !== null) {
      this.props.onMount(data);
    }
  }
```

what I think, it should

```ts
componentDidMount() {
    const data = window.localStorage.getItem(this.props.name);
    if (data && data !== null) {
      this.props.onMount(JSON.parse(data));
    }
  }
```
:D 
