### PR TITLE
Allows use of sessionStorage

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,6 +38,7 @@ class Signup extends React.Component {
       </form>
     )
   }
+}
 ```
 
 ### Props
@@ -48,6 +49,7 @@ Only a few of them!
 - `data: any`: Data to persist
 - `debounce:? number`:  Number of ms to debounce the function that saves form state. Default is `300`.
 - `onMount: (data: any) => void`: (optionally) Hydrate your data (into React state). Will only be called if data is not `null`.
+- `useSessionStorage?: boolean`: Use `sessionStorage` instead of `localStorage`. Default is `false`.
 
 
 ## Author

--- a/src/react-persist.tsx
+++ b/src/react-persist.tsx
@@ -7,6 +7,7 @@ export interface PersistProps {
   data: any;
   debounce?: number;
   onMount: (data: any) => void;
+  useSessionStorage?: boolean;
 }
 
 export class Persist extends React.Component<PersistProps, {}> {
@@ -15,7 +16,10 @@ export class Persist extends React.Component<PersistProps, {}> {
   };
 
   persist = debounce((data: any) => {
-    window.localStorage.setItem(this.props.name, JSON.stringify(data));
+    const storage = this.props.useSessionStorage
+      ? window.localStorage
+      : window.sessionStorage;
+    storage.setItem(this.props.name, JSON.stringify(data));
   }, this.props.debounce);
 
   componentWillReceiveProps({ data }: PersistProps) {

--- a/src/react-persist.tsx
+++ b/src/react-persist.tsx
@@ -29,7 +29,10 @@ export class Persist extends React.Component<PersistProps, {}> {
   }
 
   componentDidMount() {
-    const data = window.localStorage.getItem(this.props.name);
+    const storage = this.props.useSessionStorage
+      ? window.sessionStorage
+      : window.localStorage;
+    const data = storage.getItem(this.props.name);
     if (data) {
       this.props.onMount(JSON.parse(data));
     }

--- a/src/react-persist.tsx
+++ b/src/react-persist.tsx
@@ -22,15 +22,15 @@ export class Persist extends React.Component<PersistProps, {}> {
     storage.setItem(this.props.name, JSON.stringify(data));
   }, this.props.debounce);
 
-  componentWillReceiveProps({ data }: PersistProps) {
+  componentDidUpdate({ data }: PersistProps) {
     if (!isEqual(data, this.props.data)) {
-      this.persist(data);
+      this.persist(this.props.data);
     }
   }
 
   componentDidMount() {
     const data = window.localStorage.getItem(this.props.name);
-    if (data && data !== null) {
+    if (data) {
       this.props.onMount(JSON.parse(data));
     }
   }

--- a/src/react-persist.tsx
+++ b/src/react-persist.tsx
@@ -17,8 +17,8 @@ export class Persist extends React.Component<PersistProps, {}> {
 
   persist = debounce((data: any) => {
     const storage = this.props.useSessionStorage
-      ? window.localStorage
-      : window.sessionStorage;
+      ? window.sessionStorage
+      : window.localStorage;
     storage.setItem(this.props.name, JSON.stringify(data));
   }, this.props.debounce);
 


### PR DESCRIPTION
**Problem**
Need the ability to specify if `sessionStorage` or `localStorage` should be used. 

**Solution**
Add `boolean` prop `useSessionStorage` which is then used to determine the storage type to use.

**Additional**
- Updates `componentWillReceiveProps` to `componentDidUpdate`.
- Removes unnecessary `null` check.
